### PR TITLE
Exclude upstream jsonnet/doc/third_party from crates.io upload

### DIFF
--- a/jsonnet-sys/Cargo.toml
+++ b/jsonnet-sys/Cargo.toml
@@ -9,6 +9,7 @@ documentation = "https://docs.rs/jsonnet-sys"
 repository = "https://github.com/anguslees/rust-jsonnet.git"
 license = "Apache-2.0"
 description = "Native bindings to the libjsonnet library"
+exclude = ["/jsonnet/doc/third_party"]
 
 [lib]
 name = "jsonnet_sys"


### PR DESCRIPTION
jsonnet/doc/third_party contains some large tool binaries.
Exclude them from the crate so Rust consumers don't have to download them.